### PR TITLE
fix: Custom created interactive element should always have `type`

### DIFF
--- a/src/CollapsableItem.ts
+++ b/src/CollapsableItem.ts
@@ -83,6 +83,7 @@ export class CollapsableItem {
 				// noop
 			} else {
 				interactiveElement = document.createElement('button')
+				interactiveElement.type = 'button'
 				interactiveElement.dataset.caCreated = 'true'
 				interactiveElement.innerHTML = control.innerHTML
 				control.replaceChildren(interactiveElement)


### PR DESCRIPTION
fix: Custom created interactive element should always have `type="button"` set.