### PR TITLE
fix: Order of operations in constructor

### DIFF
--- a/src/CollapsableItem.ts
+++ b/src/CollapsableItem.ts
@@ -45,6 +45,7 @@ export class CollapsableItem {
 			throw new Error(`Collapsable: Missing control or box element.'`)
 		}
 
+		this.element = element as HTMLCollapsableItem
 		this.controlElements = Array.from(controlElements)
 		this.controlInteractiveElements = []
 		this.boxElements = Array.from(boxElements)
@@ -52,7 +53,6 @@ export class CollapsableItem {
 		this.prepareDOM()
 		this.addHandlers()
 
-		this.element = element as HTMLCollapsableItem
 		this.element.collapsableItem = this
 	}
 


### PR DESCRIPTION
`this.element` has to be set prior to `this.prepareDOM()` call. Now `this.element` is set immediately after we now the `CollapsableItem` is going to be instantiated.