### PR TITLE
fix: External links and multiple initializations of Collapsable

### DIFF
--- a/src/Collapsable.ts
+++ b/src/Collapsable.ts
@@ -109,11 +109,13 @@ export class Collapsable {
 		const extLinks = document.querySelectorAll<HTMLAnchorElement>(options.externalLinks.selector)
 
 		extLinks.forEach((element) => {
-			const extLink = new CollapsableExtLink(this, element)
+			const collapsableItem = this.getItemById(element.hash.substring(1))
 
-			if (extLink) {
-				this.extLinks.push(extLink)
+			if (!collapsableItem) {
+				return
 			}
+
+			this.extLinks.push(new CollapsableExtLink(this, element, collapsableItem))
 		})
 	}
 

--- a/src/CollapsableExtLink.ts
+++ b/src/CollapsableExtLink.ts
@@ -9,18 +9,11 @@ export class CollapsableExtLink {
 
 	private listener: EventListener | undefined
 
-	public constructor(collapsable: Collapsable, link: HTMLAnchorElement) {
+	public constructor(collapsable: Collapsable, link: HTMLAnchorElement, collapsableItem: CollapsableItem) {
 		this.collapsable = collapsable
 
 		if (link.tagName.toLowerCase() !== 'a') {
-			throw new Error(`Collapsable: External link has to be HTMLAnchorElement.'`)
-		}
-
-		const hash = link.getAttribute('href')?.substring(1)
-		const collapsableItem: CollapsableItem | undefined = this.collapsable.getItemById(hash)
-
-		if (!collapsableItem) {
-			throw new Error(`Collapsable: External link has no associated collapsable item.'`)
+			throw new Error('Collapsable: External link has to be HTMLAnchorElement.')
 		}
 
 		this.extLink = link


### PR DESCRIPTION
#24 When `Collapsable` is initialized more than once on a page and there is some external link, there is an error thrown into the console `Error: Collapsable: External link has no associated collapsable item.` as a result of some instances not being able to recognize the external link. From now, this is silently ignored as not an error. Also extLink