### PR TITLE
Optional control element

### DIFF
--- a/src/CollapsableItem.ts
+++ b/src/CollapsableItem.ts
@@ -41,7 +41,7 @@ export class CollapsableItem {
 		const controlElements = element.querySelectorAll<HTMLElement>(collapsable.options.control)
 		const boxElements = element.querySelectorAll<HTMLElement>(collapsable.options.box)
 
-		if (!controlElements.length || !boxElements.length) {
+		if (!boxElements.length) {
 			throw new Error(`Collapsable: Missing control or box element.'`)
 		}
 

--- a/src/CollapsableItem.ts
+++ b/src/CollapsableItem.ts
@@ -295,4 +295,12 @@ declare global {
 		'collapsed.collapsable': CollapsableEvent
 		'destroy.collapsable': CustomEvent
 	}
+
+	interface DocumentEventMap {
+		'expand.collapsable': CollapsableEvent
+		'expanded.collapsable': CollapsableEvent
+		'collapse.collapsable': CollapsableEvent
+		'collapsed.collapsable': CollapsableEvent
+		'destroy.collapsable': CustomEvent
+	}
 }


### PR DESCRIPTION
- [feature: Add `CollapsableEvent`s to `DocumentEventMap` as well](https://github.com/zipper/collapsable.js/commit/631b28c32605f5a67a534d7dd27c2811e13fe243)
- [feature: Control element is now optional](https://github.com/zipper/collapsable.js/commit/99adefb2013da6da4eb20c2e1475937086db7f1d)
  - The control element for `CollapsableItem` is now optional. If there is no control element, you can either expand / collapse the item programmatically from JS, or you can use an external link.