### PR TITLE
feature: Allow external links to be a button element

### DIFF
--- a/src/Collapsable.ts
+++ b/src/Collapsable.ts
@@ -106,10 +106,11 @@ export class Collapsable {
 			return
 		}
 
-		const extLinks = document.querySelectorAll<HTMLAnchorElement>(options.externalLinks.selector)
+		const extLinks = document.querySelectorAll<HTMLAnchorElement | HTMLButtonElement>(options.externalLinks.selector)
 
 		extLinks.forEach((element) => {
-			const collapsableItem = this.getItemById(element.hash.substring(1))
+			const hash = element instanceof HTMLAnchorElement ? element.hash.substring(1) : element.dataset.collapsableId
+			const collapsableItem = this.getItemById(hash)
 
 			if (!collapsableItem) {
 				return

--- a/src/CollapsableExtLink.ts
+++ b/src/CollapsableExtLink.ts
@@ -4,17 +4,21 @@ import { Collapsable } from './Collapsable'
 export class CollapsableExtLink {
 	private readonly collapsable: Collapsable
 
-	public readonly extLink: HTMLAnchorElement
+	public readonly extLink: HTMLAnchorElement | HTMLButtonElement
 	public readonly collapsableItem: CollapsableItem
 
 	private listener: EventListener | undefined
 	private ariaPerRole!: 'aria-expanded' | 'aria-selected' // always set by `this.prepareDOM()` called from constructor
 
-	public constructor(collapsable: Collapsable, link: HTMLAnchorElement, collapsableItem: CollapsableItem) {
+	public constructor(
+		collapsable: Collapsable,
+		link: HTMLAnchorElement | HTMLButtonElement,
+		collapsableItem: CollapsableItem
+	) {
 		this.collapsable = collapsable
 
-		if (!(link instanceof HTMLAnchorElement)) {
-			throw new Error('Collapsable: External link has to be HTMLAnchorElement.')
+		if (!(link instanceof HTMLAnchorElement) && !(link instanceof HTMLButtonElement)) {
+			throw new Error('Collapsable: External link has to be HTMLAnchorElement or HTMLButtonElement.')
 		}
 
 		this.extLink = link
@@ -27,11 +31,11 @@ export class CollapsableExtLink {
 	private prepareDOM(): void {
 		this.extLink.setAttribute('aria-controls', this.collapsableItem.boxElements.map((box) => box.id).join(' '))
 
-		if (!this.extLink.role) {
+		if (this.extLink instanceof HTMLAnchorElement && !this.extLink.role) {
 			this.extLink.role = 'button'
 		}
 
-		if (this.extLink.role === 'button') {
+		if (this.extLink instanceof HTMLButtonElement || this.extLink.role === 'button') {
 			this.ariaPerRole = 'aria-expanded'
 		} else if (this.extLink.role === 'tab') {
 			this.ariaPerRole = 'aria-selected'
@@ -44,7 +48,7 @@ export class CollapsableExtLink {
 		const { options } = this.collapsable
 
 		this.listener = (event: Event) => {
-			if (options.externalLinks.preventDefault) {
+			if (options.externalLinks.preventDefault || this.extLink.dataset.collapsablePreventDefault !== undefined) {
 				event.preventDefault()
 			}
 


### PR DESCRIPTION
External links for collapsable can now be a `HTMLButtonElement` with `data-collapsable-id` attribute. There is also an option to prevent the default action of an external link using either the option (this affects all external links for a particular `Collapsable`) or the `data-collapsable-prevent-default` attribute (this affects only a specific external link).