### PR TITLE
fix: Expand/Collapse events triggered only on state change

### DIFF
--- a/src/CollapsableItem.ts
+++ b/src/CollapsableItem.ts
@@ -181,6 +181,11 @@ export class CollapsableItem {
 	}
 
 	public expand(collapsableEvent: any, data: any, force: boolean): boolean {
+		// If the item is already expanded return
+		if (this.isExpanded) {
+			return false
+		}
+
 		const { options } = this.collapsable
 		const expandedItem = this.collapsable.getExpanded()
 
@@ -223,9 +228,12 @@ export class CollapsableItem {
 	public collapse(collapsableEvent: any, data: any, force: boolean): boolean {
 		const { options } = this.collapsable
 
-		// If we can't collapse all & we are not promised to open something & there is only one opened box, we can't
-		// continue
-		if (!options.collapsableAll && !this.collapsable.promiseOpen && this.collapsable.getExpanded().length < 2) {
+		// If the item is not expanded, or if we can't collapse all & we are not promised to open something & there is
+		// only one opened box, we can't continue
+		if (
+			!this.isExpanded ||
+			(!options.collapsableAll && !this.collapsable.promiseOpen && this.collapsable.getExpanded().length < 2)
+		) {
 			return false
 		}
 


### PR DESCRIPTION
Expand and collapse events are now dispatched only when the action is actually performed. For example, if an item is already expanded, calling the expand method will not dispatch `expand.collapsable` or `expanded.collapsable` events, since no action occurred. Previously, these events were dispatched regardless of the state. The same behavior change has been applied to collapse-related events.