### PR TITLE
feature: `CollapsableItem` can be initialized based on media queries

### DIFF
--- a/src/Collapsable.ts
+++ b/src/Collapsable.ts
@@ -87,7 +87,6 @@ export class Collapsable {
 
 		this.handleExternalLinks()
 
-		this.prepareDefaultExpanded()
 		this.handleDefaultExpanded()
 	}
 
@@ -145,7 +144,9 @@ export class Collapsable {
 		}
 	}
 
-	private handleDefaultExpanded(): void {
+	public handleDefaultExpanded(): void {
+		this.prepareDefaultExpanded()
+
 		const { options } = this
 		const collapsableEvent = new CustomEvent('init.collapsable', { bubbles: true })
 


### PR DESCRIPTION
`CollapsableItem` can be initialized based on media queries. This allows it to exist only at specific breakpoints, while at others, the DOM is reverted and remains unmodified. This is particularly useful for components like mobile menus and helps resolve accessibility issues where an item had a `hidden` attribute but was later made visible via CSS.