### PR TITLE
Feature data collapsable state

### DIFF
--- a/src/Collapsable.ts
+++ b/src/Collapsable.ts
@@ -7,7 +7,7 @@ export type CollapsableOptions = {
 	box: string
 	event: string
 	preventDefault: boolean
-	fxDuration: 0
+	fxDuration: number
 	accordion: boolean
 	collapsableAll: boolean
 	externalLinks: {


### PR DESCRIPTION
While a `CollapsableItem` is expanding or collapsing, the `data-collapsable-state` attribute is set to `expanding` or `collapsing`. This attribute is removed immediately after the transition completes.

This can be useful in CSS, for example, to apply `@starting-style` only to the item currently expanding or collapsing. This makes it easier to use `display: none` for hiding collapsed items while still allowing transitions for expansion. Additionally, when applied via the data attribute, `@starting-style` won’t affect nested collapsable elements that are already expanded, preventing unwanted transitions.