### PR TITLE
feature: Automatically detect delay for `[expanded|collapsed].collapsable` events

### DIFF
--- a/src/Collapsable.ts
+++ b/src/Collapsable.ts
@@ -7,7 +7,8 @@ export type CollapsableOptions = {
 	box: string
 	event: string
 	preventDefault: boolean
-	fxDuration: number
+	eventDelayTimeout: number | undefined
+	eventDelayGetAnimationsWithSubtree: boolean
 	accordion: boolean
 	collapsableAll: boolean
 	externalLinks: {
@@ -39,9 +40,15 @@ export class Collapsable {
 		event: 'click',
 		preventDefault: true,
 
-		// Duration of the effect, affects delay between `expand.collapsable`(`collapse.collapsable`) and
-		// `expanded.collapsable` (`collapsed.collapsable`) events are triggered.
-		fxDuration: 0,
+		// The duration of the effect (expanding or collapsing). By default, the delay for `expanded.collapsable` and
+		// `collapsed.collapsable` events is influenced by transitions on box elements. However, since some box elements
+		// may have infinite animations, this option allows setting a maximum delay to ensure the events are dispatched
+		// eventually. Default value of undefined means, that we always wait for all animations to finish.
+		eventDelayTimeout: undefined,
+
+		// By default, `getAnimations` for detecting animations on box elements doesn't include subtree. This options
+		// allows you to include subtree animations as well.
+		eventDelayGetAnimationsWithSubtree: false,
 
 		// Determines, if there could be more than one expanded box in same time.
 		accordion: false,


### PR DESCRIPTION
Previously, the delay for the `[expanded|collapsed].collapsable` events was defined by the `fxDuration` option. From this version, the delay is automatically detected using the Web Animations API from the box elements. Optionally, you can also detect animations within the subtree of box elements using the `eventDelayGetAnimationsWithSubtree` option.

The `fxDuration` option has been renamed to `eventDelayTimeout`. Since the box may contain elements with infinite animations (or the box itself may have such animations), a hard timeout may be required to ensure that the `[expanded|collapsed].collapsable` events are dispatched eventually. This timeout can now be set using the renamed `eventDelayTimeout` option. Default value is undefined, meaning that no timeout is set.