### PR TITLE
Various fixes

### DIFF
--- a/src/CollapsableExtLink.ts
+++ b/src/CollapsableExtLink.ts
@@ -74,6 +74,7 @@ export class CollapsableExtLink {
 			this.extLink.removeEventListener('click', this.listener)
 			this.extLink.removeAttribute('aria-controls')
 			this.extLink.removeAttribute(this.ariaPerRole)
+			this.extLink.removeAttribute('role')
 		}
 	}
 }

--- a/src/CollapsableItem.ts
+++ b/src/CollapsableItem.ts
@@ -179,6 +179,10 @@ export class CollapsableItem {
 	 * Handling common parts of expanding and collapsing
 	 */
 	private handleExpandCollapse(action: CollapsableItemAction, collapsableEvent: any, data: any): boolean {
+		if (this.media && !this.media.matches) {
+			return false
+		}
+
 		const { options } = this.collapsable
 		let eventName: CollapsableItemEvents = 'expanded.collapsable'
 		let addClass = options.classNames.expanded

--- a/src/CollapsableItem.ts
+++ b/src/CollapsableItem.ts
@@ -418,6 +418,7 @@ export class CollapsableItem {
 		this.boxElements.forEach((box) => {
 			box.removeAttribute('aria-hidden')
 			box.removeAttribute('hidden')
+			delete box.dataset.collapsableState
 		})
 
 		this.element.dispatchEvent(new CustomEvent('destroy.collapsable', { bubbles: true }))

--- a/src/CollapsableItem.ts
+++ b/src/CollapsableItem.ts
@@ -17,7 +17,7 @@ type ListenersMapItem = {
 
 type CollapsableElementListeners = {
 	eventName: CollapsableItemEvents
-	listener: EventListener
+	listener: (event: CollapsableEvent) => void
 }
 
 export interface HTMLCollapsableItem extends HTMLElement {
@@ -121,6 +121,7 @@ export class CollapsableItem {
 
 	private addHandlers(): void {
 		const { options } = this.collapsable
+		const collapsableElement = this.element
 		const interactiveElementsListener = (event: CustomEvent) => {
 			const passEvent = event.detail.collapsableEvent ?? event
 
@@ -137,19 +138,39 @@ export class CollapsableItem {
 		const collapsableListeners: CollapsableElementListeners[] = [
 			{
 				eventName: 'expand.collapsable',
-				listener: () => this.boxElements.forEach((box) => (box.dataset.collapsableState = 'expanding'))
+				listener: (event: CollapsableEvent) => {
+					if (event.target !== collapsableElement) {
+						return
+					}
+					this.boxElements.forEach((box) => (box.dataset.collapsableState = 'expanding'))
+				}
 			},
 			{
 				eventName: 'collapse.collapsable',
-				listener: () => this.boxElements.forEach((box) => (box.dataset.collapsableState = 'collapsing'))
+				listener: (event: CollapsableEvent) => {
+					if (event.target !== collapsableElement) {
+						return
+					}
+					this.boxElements.forEach((box) => (box.dataset.collapsableState = 'collapsing'))
+				}
 			},
 			{
 				eventName: 'expanded.collapsable',
-				listener: () => this.boxElements.forEach((box) => delete box.dataset.collapsableState)
+				listener: (event: CollapsableEvent) => {
+					if (event.target !== collapsableElement) {
+						return
+					}
+					this.boxElements.forEach((box) => delete box.dataset.collapsableState)
+				}
 			},
 			{
 				eventName: 'collapsed.collapsable',
-				listener: () => this.boxElements.forEach((box) => delete box.dataset.collapsableState)
+				listener: (event: CollapsableEvent) => {
+					if (event.target !== collapsableElement) {
+						return
+					}
+					this.boxElements.forEach((box) => delete box.dataset.collapsableState)
+				}
 			}
 		]
 
@@ -165,7 +186,7 @@ export class CollapsableItem {
 			this.addCollapsableEventListener({
 				element: this.element,
 				eventName: collapsableListener.eventName,
-				listener: collapsableListener.listener
+				listener: collapsableListener.listener as EventListener
 			})
 		})
 	}


### PR DESCRIPTION
- [fix: Check for responsive collapsable in handleExpandCollapse](https://github.com/zipper/collapsable.js/pull/37/commits/93e17559ceef280b0fc4470300bf71ea85288621)
   The `handleExpandCollapse` method checks whether the collapsable element is responsive. If it is, the method proceeds only if the media query matches.
- [fix: Better handling of dataset.collapsableState](https://github.com/zipper/collapsable.js/pull/37/commits/6262231f007832fefdaf3087452d7e7cae7515d4)
   The `dataset.collapsableState` is modified only when `CollapsableEvent`s are associated with the expanding or collapsing elements. This ensures that events from nested collapsable elements do not affect the `dataset.collapsableState` further up the DOM tree.
- [fix: Better attribute clean up on destroy](https://github.com/zipper/collapsable.js/pull/37/commits/5dce013aa45b0faa601c61df1f32157f3f1e8065)
   On destroy, the `dataset.collapsableState` is removed from boxes, and the `role` attribute is removed from `extLink`.